### PR TITLE
Undo changes from #2387

### DIFF
--- a/serde_derive/src/de.rs
+++ b/serde_derive/src/de.rs
@@ -1010,7 +1010,7 @@ fn deserialize_struct(
     } else {
         let field_names = field_names_idents
             .iter()
-            .flat_map(|&(_, _, aliases)| aliases);
+            .map(|&(name, _, _)| name);
 
         Some(quote! {
             #[doc(hidden)]


### PR DESCRIPTION
This is an experiment with undoing the changes from https://github.com/serde-rs/serde/pull/2387 (but using the latest serde code) in an attempt to fix the issue we're seeing with serde alias when using serde versions at or greater than 1.0.153.